### PR TITLE
Fix issue with GET request and no params

### DIFF
--- a/lib/easypost/helpers/url.ex
+++ b/lib/easypost/helpers/url.ex
@@ -10,8 +10,8 @@ defmodule EasyPost.Helpers.URL do
     |> URI.to_string()
   end
 
-  defp put_query(uri, %{ method: :get } = operation) do
-    Map.put(uri, :query, URI.encode_query(operation.params))
+  defp put_query(uri, %{method: :get, params: params}) when not is_nil(params) do
+    Map.put(uri, :query, URI.encode_query(params))
   end
 
   defp put_query(uri, _operation) do

--- a/test/easypost/helpers/url_test.exs
+++ b/test/easypost/helpers/url_test.exs
@@ -1,15 +1,19 @@
 defmodule EasyPost.Helpers.URLTest do
   use ExUnit.Case, async: true
 
-  alias EasyPost.{ Config, Helpers, Operation }
+  alias EasyPost.{Config, Helpers, Operation}
 
   test "to_string/2" do
-    operation = %Operation{ method: :post, path: "/hi", params: %{ good: "morning" } }
+    operation = %Operation{method: :post, path: "/hi", params: %{good: "morning"}}
 
     assert "https://api.easypost.com/v2/hi" == Helpers.URL.to_string(operation, Config.new())
 
-    operation = %Operation{ method: :get, path: "/hi", params: %{ good: "morning" } }
+    operation = %Operation{method: :get, path: "/hi", params: %{good: "morning"}}
 
-    assert "https://api.easypost.com/v2/hi?good=morning" == Helpers.URL.to_string(operation, Config.new())
+    assert "https://api.easypost.com/v2/hi?good=morning" ==
+             Helpers.URL.to_string(operation, Config.new())
+
+    operation = %Operation{method: :get, path: "/hi"}
+    assert "https://api.easypost.com/v2/hi" == Helpers.URL.to_string(operation, Config.new())
   end
 end


### PR DESCRIPTION
When no params are given to a GET request, the library crashes with an
enumeration error.  This is because URI.encode_query(nil) is not
allowed.  Instead, don't try to set the query on the URI.