### PR TITLE
Fix convert label function

### DIFF
--- a/lib/easypost/shipment.ex
+++ b/lib/easypost/shipment.ex
@@ -19,7 +19,7 @@ defmodule EasyPost.Shipment do
     %EasyPost.Operation{
       method: :get,
       params: params,
-      path: "/shipments/#{id}"
+      path: "/shipments/#{id}/label"
     }
   end
 


### PR DESCRIPTION
Convert label is calling the wrong URL when trying to convert a PNG
label to another format.  Switch to the correct path.